### PR TITLE
Improve logging reliability and XML handling

### DIFF
--- a/pfSense/etc/context.d/firewall/firewall.sh
+++ b/pfSense/etc/context.d/firewall/firewall.sh
@@ -27,6 +27,8 @@ main()
 
     if [ "$FIREWALL_LOG" = "off" ]; then
         CONTEXT_FW_LOG=/dev/null
+    else
+        ensure_log_file "$CONTEXT_FW_LOG"
     fi
 
     if [ "$CONTEXT_FW_DEBUG" = "on" ]; then
@@ -52,7 +54,8 @@ main()
         exit 0
     fi
 
-    require_cmd xml
+    detect_xml_tool
+    log_info "Using XML tool: $CONTEXT_FW_XML_BIN"
 
     backup_xml=${backup_xml_file:-/cf/conf/config.xml}
     if [ ! -f "$backup_xml" ]; then

--- a/pfSense/etc/context.d/firewall/mod_forward.sh
+++ b/pfSense/etc/context.d/firewall/mod_forward.sh
@@ -13,7 +13,7 @@
 list_lan_interfaces()
 {
     work_xml=$1
-    xml sel -t -m "//interfaces/*" -v "concat(name(),'|',if,'|',descr)" -n "$work_xml" 2>/dev/null |
+    xml_select -t -m "//interfaces/*" -v "concat(name(),'|',if,'|',descr)" -n "$work_xml" 2>/dev/null |
         while IFS='|' read -r ifname ifdev ifdescr; do
             ifdescr_lc=$(printf '%s' "$ifdescr" | tr '[:upper:]' '[:lower:]')
             if [ "${ifdescr_lc#*wan}" != "$ifdescr_lc" ]; then
@@ -31,7 +31,7 @@ fail_safe_check()
     work_xml=$1
     lan_list=$2
     for lan in $lan_list; do
-        suspicious=$(xml sel -t -m "//filter/rule[type='pass' and interface='$lan' and not(starts-with(descr,'$CONTEXT_FW_PREFIX'))]" -v "descr" -n "$work_xml" 2>/dev/null)
+        suspicious=$(xml_select -t -m "//filter/rule[type='pass' and interface='$lan' and not(starts-with(descr,'$CONTEXT_FW_PREFIX'))]" -v "descr" -n "$work_xml" 2>/dev/null)
         if [ -n "$suspicious" ]; then
             log_warn "Fail-safe: found non-context pass rule on $lan: $suspicious"
         fi
@@ -41,7 +41,7 @@ fail_safe_check()
 clear_context_forward_rules()
 {
     work_xml=$1
-    xml ed -L -d "//filter/rule[starts-with(descr,'$CONTEXT_FW_PREFIX') and not(starts-with(descr,'$CONTEXT_FW_PREFIX DNAT allow'))]" "$work_xml" 2>/dev/null || true
+    xml_edit -L -d "//filter/rule[starts-with(descr,'$CONTEXT_FW_PREFIX') and not(starts-with(descr,'$CONTEXT_FW_PREFIX DNAT allow'))]" "$work_xml" 2>/dev/null || true
 }
 
 append_filter_rule()
@@ -56,7 +56,7 @@ append_filter_rule()
     dst_value=$8
     descr=$9
 
-    xml ed -L \
+    xml_edit -L \
         -s "//filter" -t elem -n "ruleTMP" -v "" \
         -s "//filter/ruleTMP" -t elem -n "type" -v "$type" \
         -s "//filter/ruleTMP" -t elem -n "interface" -v "$interface" \
@@ -66,21 +66,21 @@ append_filter_rule()
         "$work_xml" >/dev/null
 
     case $src_type in
-        any) xml ed -L -s "//filter/ruleTMP/source" -t elem -n "any" -v "" "$work_xml" >/dev/null ;;
-        network) xml ed -L -s "//filter/ruleTMP/source" -t elem -n "network" -v "$src_value" "$work_xml" >/dev/null ;;
-        address) xml ed -L -s "//filter/ruleTMP/source" -t elem -n "address" -v "$src_value" "$work_xml" >/dev/null ;;
-        alias) xml ed -L -s "//filter/ruleTMP/source" -t elem -n "address" -v "$src_value" "$work_xml" >/dev/null ;;
+        any) xml_edit -L -s "//filter/ruleTMP/source" -t elem -n "any" -v "" "$work_xml" >/dev/null ;;
+        network) xml_edit -L -s "//filter/ruleTMP/source" -t elem -n "network" -v "$src_value" "$work_xml" >/dev/null ;;
+        address) xml_edit -L -s "//filter/ruleTMP/source" -t elem -n "address" -v "$src_value" "$work_xml" >/dev/null ;;
+        alias) xml_edit -L -s "//filter/ruleTMP/source" -t elem -n "address" -v "$src_value" "$work_xml" >/dev/null ;;
     esac
 
-    xml ed -L -s "//filter/ruleTMP" -t elem -n "destination" -v "" "$work_xml" >/dev/null
+    xml_edit -L -s "//filter/ruleTMP" -t elem -n "destination" -v "" "$work_xml" >/dev/null
     case $dst_type in
-        any) xml ed -L -s "//filter/ruleTMP/destination" -t elem -n "any" -v "" "$work_xml" >/dev/null ;;
-        network) xml ed -L -s "//filter/ruleTMP/destination" -t elem -n "network" -v "$dst_value" "$work_xml" >/dev/null ;;
-        address) xml ed -L -s "//filter/ruleTMP/destination" -t elem -n "address" -v "$dst_value" "$work_xml" >/dev/null ;;
-        alias) xml ed -L -s "//filter/ruleTMP/destination" -t elem -n "address" -v "$dst_value" "$work_xml" >/dev/null ;;
+        any) xml_edit -L -s "//filter/ruleTMP/destination" -t elem -n "any" -v "" "$work_xml" >/dev/null ;;
+        network) xml_edit -L -s "//filter/ruleTMP/destination" -t elem -n "network" -v "$dst_value" "$work_xml" >/dev/null ;;
+        address) xml_edit -L -s "//filter/ruleTMP/destination" -t elem -n "address" -v "$dst_value" "$work_xml" >/dev/null ;;
+        alias) xml_edit -L -s "//filter/ruleTMP/destination" -t elem -n "address" -v "$dst_value" "$work_xml" >/dev/null ;;
     esac
 
-    xml ed -L -r "//filter/ruleTMP" -v "rule" "$work_xml" >/dev/null
+    xml_edit -L -r "//filter/ruleTMP" -v "rule" "$work_xml" >/dev/null
 }
 
 apply_forward_module()

--- a/pfSense/etc/context.d/firewall/mod_nat.sh
+++ b/pfSense/etc/context.d/firewall/mod_nat.sh
@@ -20,12 +20,12 @@ add_or_replace_alias()
 
     [ -n "$alias_content" ] || {
         log_debug "Alias $alias_name empty — removing if exists"
-        xml ed -L -d "//aliases/alias[name='$alias_name']" "$work_xml" 2>/dev/null || true
+        xml_edit -L -d "//aliases/alias[name='$alias_name']" "$work_xml" 2>/dev/null || true
         return 0
     }
 
-    xml ed -L -d "//aliases/alias[name='$alias_name']" "$work_xml" 2>/dev/null || true
-    xml ed -L \
+    xml_edit -L -d "//aliases/alias[name='$alias_name']" "$work_xml" 2>/dev/null || true
+    xml_edit -L \
         -s "//aliases" -t elem -n "aliasTMP" -v "" \
         -s "//aliases/aliasTMP" -t elem -n "name" -v "$alias_name" \
         -s "//aliases/aliasTMP" -t elem -n "type" -v "$alias_type" \
@@ -38,7 +38,7 @@ add_or_replace_alias()
 clear_context_outbound_rules()
 {
     work_xml=$1
-    xml ed -L -d "//nat/outbound/rule[starts-with(descr,'$CONTEXT_FW_PREFIX')]" "$work_xml" 2>/dev/null || true
+    xml_edit -L -d "//nat/outbound/rule[starts-with(descr,'$CONTEXT_FW_PREFIX')]" "$work_xml" 2>/dev/null || true
 }
 
 append_outbound_rule()
@@ -48,7 +48,7 @@ append_outbound_rule()
     source_type=$3
     descr=$4
 
-    xml ed -L \
+    xml_edit -L \
         -s "//nat/outbound" -t elem -n "ruleTMP" -v "" \
         -s "//nat/outbound/ruleTMP" -t elem -n "interface" -v "$FIREWALL_NAT_OUT_IF" \
         -s "//nat/outbound/ruleTMP" -t elem -n "protocol" -v "any" \
@@ -69,9 +69,9 @@ configure_outbound_nat()
         return 0
     fi
 
-    xml ed -L -u "//nat/outbound/mode" -v "advanced" "$work_xml" 2>/dev/null || {
+    xml_edit -L -u "//nat/outbound/mode" -v "advanced" "$work_xml" 2>/dev/null || {
         # Ensure mode node exists
-        xml ed -L -s "//nat/outbound" -t elem -n "mode" -v "advanced" "$work_xml" >/dev/null
+        xml_edit -L -s "//nat/outbound" -t elem -n "mode" -v "advanced" "$work_xml" >/dev/null
     }
 
     clear_context_outbound_rules "$work_xml"


### PR DESCRIPTION
## Summary
- ensure the firewall module initialises a writable log file (with stderr mirroring fallback) before emitting messages
- detect and log the available xml/xmlstarlet binary once, then wrap all XML edits/selections through helper functions
- update all NAT, DNAT, and forward modules to use the shared XML helpers for consistent behaviour

## Testing
- sh -n firewall.sh functions.sh mod_nat.sh mod_dnat.sh mod_forward.sh vars.sh

------
https://chatgpt.com/codex/tasks/task_e_68eb9295d2fc8328903007ee96b9af31