### PR TITLE
Automate management interface context handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@
 ### Сеть
 - `ETHx_MAC` — привязка интерфейса к MAC-адресу на хосте.
 - `ETHx_TYPE` — требуемая роль (`lan`, `wan`, `optN`), определяет раздел `<interfaces>`.
+- `ETHx_TYPE="mgmt"` — назначает интерфейс в качестве управленческого, принудительно помечая его как OPT с описанием `MGMT` и
+  сохраняя IP для автоматического создания правил доступа.
 - `ETHx_IP` / `ETHx_MASK` — IPv4-адрес и маска, записываемые в `config.xml`.
 - `ETHx_GATEWAY` — шлюз по умолчанию для WAN-интерфейса.
 - `ETHx_DNS` — список DNS-серверов, применяемых к системе и `config.xml`.
@@ -65,6 +67,10 @@
 - `PASSWORD` — новый пароль пользователя `admin` (через `ChangePassTool`).
 - `SSH_PUBLIC_KEY` — публичный SSH-ключ для `admin` (base64 → `config.xml`).
 - `PFCTL` — целевое состояние firewall (`on`/`off`).
+- `MGMT_ENABLE` — включает генерацию правил для менеджмент-интерфейса (`on`/`off`).
+- `MGMT_ALLOWED_IPS` — список IPv4-адресов/подсетей, которым разрешено подключаться к управленческому интерфейсу (пробел/запятая).
+- `MGMT_TCP_PORTS` — TCP-порты для доступа (по умолчанию `443 80 22`). Правила применяются мгновенно, а весь прочий IPv4/IPv6
+  трафик на интерфейсе блокируется в направлении `out`.
 - `BLOCK_PRIVATE_NETWORKS` — сохраняет фильтр `blockpriv` на WAN при `on`.
 - `BLOCK_BOGON_NETWORKS` — сохраняет фильтр `blockbogons` на WAN при `on`
 
@@ -99,6 +105,15 @@ ETH1_TYPE="lan"
 ETH1_IP="192.168.10.1"
 ETH1_MASK="255.255.255.0"
 ETH1_DNS="192.168.10.1"
+
+ETH2_MAC="00:50:56:aa:bb:03"
+ETH2_TYPE="mgmt"
+ETH2_IP="91.185.11.71"
+ETH2_MASK="255.255.255.240"
+
+MGMT_ENABLE="on"
+MGMT_ALLOWED_IPS="91.185.11.70"
+MGMT_TCP_PORTS="443 80 22"
 
 SET_HOSTNAME="pfsense-demo"
 PFCTL="off"

--- a/pfSense/etc/context.d/ContextOnly
+++ b/pfSense/etc/context.d/ContextOnly
@@ -87,6 +87,8 @@ apply_wan_gateway "$xml_file" "$backup_xml_file" "$LOG" "$current_gw" "$WAN_GATE
 # Применение фильтров WAN
 handle_bgp_default_route "$backup_xml_file" "$LOG" "$WAN_GATEWAY"
 apply_wan_filters "$backup_xml_file" "$LOG" "$WAN_NETWORK"
+# Правила firewall для менеджмент-интерфейса
+prepare_mgmt_firewall_rules "$backup_xml_file" "$LOG"
 
 # Синхронизация config.xml (если есть изменения)
 if diff -I '<bcrypt-hash>.*</bcrypt-hash>' -q "$xml_file" "$backup_xml_file" >/dev/null; then
@@ -96,6 +98,8 @@ elif [ -s "$backup_xml_file" ]; then # Если файл не пустой, ко
     cp "$backup_xml_file" "$xml_file"
     echo "$(date) [context] config.xml updated, backup_xml_file saved to $backup_xml_file" >> "$LOG"
 fi
+# Применение firewall после обновления конфигурации
+apply_mgmt_firewall_runtime "$LOG"
 # Перезагрузка служб pfSense (если указано в контексте)
 if [ "${RC_RELOAD_ALL}" = "on" ]; then
     # Перезагружаем службы pfSense

--- a/pfSense/etc/context.d/modules/firewall.sh
+++ b/pfSense/etc/context.d/modules/firewall.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+
+# Firewall-related helpers for ContextOnly.
+
+MGMT_SHOULD_APPLY="off"
+
+_firewall_log() {
+    log_file="$1"
+    message="$2"
+    if [ -n "$log_file" ]; then
+        printf '%s [context-firewall] %s\n' "$(date)" "$message" >> "$log_file"
+    fi
+}
+
+_firewall_find_php() {
+    if [ -x /usr/local/bin/php ]; then
+        printf '%s' "/usr/local/bin/php"
+    elif command -v php >/dev/null 2>&1; then
+        command -v php
+    else
+        printf '%s' ""
+    fi
+}
+
+_firewall_normalize_bool() {
+    value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+    case "$value" in
+        1|true|yes|on|enabled)
+            printf '%s' "on"
+            ;;
+        *)
+            printf '%s' ""
+            ;;
+    esac
+}
+
+_prepare_mgmt_sources() {
+    for candidate in MGMT_ALLOWED_SOURCES MGMT_ALLOWED_IPS MGMT_SOURCE_ADDRESSES MGMT_SOURCE_IPS MGMT_SOURCE; do
+        eval "val=\${$candidate:-}"
+        if [ -n "$val" ]; then
+            printf '%s' "$val"
+            return 0
+        fi
+    done
+    return 1
+}
+
+prepare_mgmt_firewall_rules() {
+    backup_file="$1"
+    log_file="$2"
+    php_bin="$(_firewall_find_php)"
+    script="$SCRIPT_DIR/modules/firewall_mgmt.php"
+
+    mgmt_enabled=$(_firewall_normalize_bool "${MGMT_ENABLE:-${MGMT_ENABLED:-}}")
+    mgmt_targets=$(printf '%s' "${MGMT_TARGETS:-}" | tr '\n' ' ' | sed -E -e 's/[[:space:]]+/ /g' -e 's/^ //' -e 's/ $//')
+    mgmt_sources=$(_prepare_mgmt_sources || printf '%s' "")
+    mgmt_ports="${MGMT_TCP_PORTS:-${MGMT_PORTS:-}}"
+
+    if [ ! -f "$script" ]; then
+        _firewall_log "$log_file" "firewall_mgmt.php not found, skipping management firewall provisioning"
+        return 0
+    fi
+
+    if [ -z "$php_bin" ]; then
+        _firewall_log "$log_file" "php binary not found, unable to manage firewall rules"
+        return 1
+    fi
+
+    output=$("$php_bin" "$script" prepare "$backup_file" "$log_file" "${mgmt_enabled:-off}" "${mgmt_targets:-}" "${mgmt_sources:-}" "${mgmt_ports:-}" 2>>"$log_file")
+    status=$?
+    if [ $status -ne 0 ]; then
+        _firewall_log "$log_file" "management firewall provisioning command failed (exit $status)"
+        MGMT_SHOULD_APPLY="off"
+        return $status
+    fi
+
+    if printf '%s' "$output" | grep -q 'CHANGED=1'; then
+        MGMT_SHOULD_APPLY="on"
+        _firewall_log "$log_file" "management firewall rules updated"
+    else
+        MGMT_SHOULD_APPLY="off"
+        _firewall_log "$log_file" "management firewall rules unchanged"
+    fi
+}
+
+apply_mgmt_firewall_runtime() {
+    log_file="$1"
+    php_bin="$(_firewall_find_php)"
+    script="$SCRIPT_DIR/modules/firewall_mgmt.php"
+
+    if [ "${MGMT_SHOULD_APPLY:-off}" != "on" ]; then
+        _firewall_log "$log_file" "skip firewall apply (no changes detected)"
+        return 0
+    fi
+
+    if [ ! -f "$script" ]; then
+        _firewall_log "$log_file" "firewall_mgmt.php not found, cannot apply firewall rules"
+        return 0
+    fi
+
+    if [ -z "$php_bin" ]; then
+        _firewall_log "$log_file" "php binary not found, cannot apply firewall rules"
+        return 1
+    fi
+
+    if "$php_bin" "$script" apply "$log_file" >>"$log_file" 2>&1; then
+        _firewall_log "$log_file" "management firewall rules applied"
+    else
+        _firewall_log "$log_file" "failed to apply management firewall rules"
+        return 1
+    fi
+}

--- a/pfSense/etc/context.d/modules/firewall_mgmt.php
+++ b/pfSense/etc/context.d/modules/firewall_mgmt.php
@@ -1,0 +1,342 @@
+#!/usr/local/bin/php
+<?php
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This script must be executed from the command line\n");
+    exit(1);
+}
+
+array_shift($argv);
+$mode = $argv[0] ?? '';
+
+switch ($mode) {
+    case 'prepare':
+        $backupFile = $argv[1] ?? '';
+        $logFile = $argv[2] ?? '';
+        $enabledFlag = $argv[3] ?? 'off';
+        $targetsRaw = $argv[4] ?? '';
+        $sourcesRaw = $argv[5] ?? '';
+        $portsRaw = $argv[6] ?? '';
+
+        $enabled = normalize_bool($enabledFlag);
+        $targets = parse_targets($targetsRaw);
+        $sources = parse_list($sourcesRaw);
+        $ports = parse_ports($portsRaw);
+        if (empty($ports)) {
+            $ports = ['443', '80', '22'];
+        }
+
+        $changed = false;
+
+        if (!is_readable($backupFile)) {
+            log_message($logFile, sprintf('backup config "%s" is not readable', $backupFile));
+            echo "CHANGED=0\n";
+            exit(1);
+        }
+
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc->preserveWhiteSpace = false;
+        $doc->formatOutput = true;
+        if (!$doc->load($backupFile)) {
+            log_message($logFile, sprintf('failed to parse XML backup "%s"', $backupFile));
+            echo "CHANGED=0\n";
+            exit(1);
+        }
+        $xpath = new DOMXPath($doc);
+        $filterNode = ensure_filter_node($doc, $xpath);
+
+        $removed = remove_existing_rules($xpath, $filterNode);
+        if ($removed > 0) {
+            $changed = true;
+            log_message($logFile, sprintf('removed %d existing management firewall rule(s)', $removed));
+        }
+
+        if ($enabled && empty($targets)) {
+            log_message($logFile, 'management firewall enabled but no MGMT targets detected');
+            $enabled = false;
+        }
+
+        if ($enabled && empty($sources)) {
+            log_message($logFile, 'management firewall enabled but no allowed source addresses provided');
+            $enabled = false;
+        }
+
+        if ($enabled) {
+            $now = time();
+            foreach ($targets as $target) {
+                $iface = $target['interface'];
+                $address = $target['address'];
+                $label = get_interface_label($xpath, $iface);
+                foreach ($sources as $source) {
+                    foreach ($ports as $port) {
+                        $descr = sprintf('[CTX-MGMT] Allow %s management TCP port %s', $label, $port);
+                        append_rule($doc, $filterNode, [
+                            'type' => 'pass',
+                            'interface' => $iface,
+                            'ipprotocol' => 'inet',
+                            'protocol' => 'tcp',
+                            'statetype' => 'keep state',
+                            'source' => $source,
+                            'destination' => $address,
+                            'destination_port' => $port,
+                            'descr' => $descr,
+                            'timestamp' => $now,
+                        ]);
+                        $changed = true;
+                    }
+                }
+
+                $descr4 = sprintf('[CTX-MGMT] Block %s outbound IPv4', $label);
+                append_rule($doc, $filterNode, [
+                    'type' => 'block',
+                    'interface' => $iface,
+                    'ipprotocol' => 'inet',
+                    'direction' => 'out',
+                    'source' => 'any',
+                    'destination' => 'any',
+                    'descr' => $descr4,
+                    'timestamp' => $now,
+                ]);
+                $changed = true;
+
+                $descr6 = sprintf('[CTX-MGMT] Block %s outbound IPv6', $label);
+                append_rule($doc, $filterNode, [
+                    'type' => 'block',
+                    'interface' => $iface,
+                    'ipprotocol' => 'inet6',
+                    'direction' => 'out',
+                    'source' => 'any',
+                    'destination' => 'any',
+                    'descr' => $descr6,
+                    'timestamp' => $now,
+                ]);
+            }
+
+            log_message($logFile, sprintf('provisioned management firewall rules for %d interface(s)', count($targets)));
+        } else {
+            if (!$enabled) {
+                log_message($logFile, 'management firewall provisioning disabled by context or missing parameters');
+            }
+        }
+
+        if ($changed) {
+            $doc->save($backupFile);
+        }
+
+        echo 'CHANGED=' . ($changed ? '1' : '0') . PHP_EOL;
+        exit(0);
+
+    case 'apply':
+        $logFile = $argv[1] ?? '';
+        log_message($logFile, 'requesting pf filter reload for management firewall rules');
+        require_once 'config.inc';
+        require_once 'filter.inc';
+        require_once 'util.inc';
+        $result = filter_configure();
+        if ($result === 0 || $result === true) {
+            log_message($logFile, 'pf filter reload completed for management rules');
+        } else {
+            log_message($logFile, sprintf('pf filter reload returned %s', var_export($result, true)));
+        }
+        echo "APPLIED=1\n";
+        exit(0);
+
+    default:
+        fwrite(STDERR, "Usage: firewall_mgmt.php prepare <backup> <log> <enabled> <targets> <sources> <ports> | apply <log>\n");
+        exit(1);
+}
+
+function normalize_bool(string $value): bool
+{
+    $value = strtolower(trim($value));
+    return in_array($value, ['1', 'true', 'yes', 'on', 'enabled'], true);
+}
+
+function parse_targets(string $raw): array
+{
+    $targets = [];
+    $raw = trim($raw);
+    if ($raw === '') {
+        return $targets;
+    }
+
+    foreach (preg_split('/\s+/', $raw) as $token) {
+        if ($token === '') {
+            continue;
+        }
+        [$iface, $address] = array_pad(explode(':', $token, 2), 2, '');
+        $iface = trim($iface);
+        $address = trim($address);
+        if ($iface === '' || $address === '') {
+            continue;
+        }
+        $targets[] = ['interface' => $iface, 'address' => $address];
+    }
+
+    return $targets;
+}
+
+function parse_list(string $raw): array
+{
+    $raw = trim($raw);
+    if ($raw === '') {
+        return [];
+    }
+    $items = [];
+    foreach (preg_split('/[\s,;]+/', $raw) as $part) {
+        $part = trim($part);
+        if ($part === '') {
+            continue;
+        }
+        $items[$part] = true;
+    }
+    return array_keys($items);
+}
+
+function parse_ports(string $raw): array
+{
+    $ports = [];
+    $raw = trim($raw);
+    if ($raw === '') {
+        return $ports;
+    }
+
+    foreach (preg_split('/[\s,;]+/', $raw) as $part) {
+        $part = trim($part);
+        if ($part === '') {
+            continue;
+        }
+        if (ctype_digit($part)) {
+            $port = (int)$part;
+            if ($port >= 1 && $port <= 65535) {
+                $ports[(string)$port] = true;
+            }
+        }
+    }
+
+    return array_keys($ports);
+}
+
+function log_message(string $logFile, string $message): void
+{
+    if ($logFile === '') {
+        return;
+    }
+    $line = sprintf("%s [context-firewall] %s\n", date('c'), $message);
+    file_put_contents($logFile, $line, FILE_APPEND);
+}
+
+function ensure_filter_node(DOMDocument $doc, DOMXPath $xpath): DOMElement
+{
+    $nodes = $xpath->query('/pfsense/filter');
+    if ($nodes->length > 0) {
+        return $nodes->item(0);
+    }
+    $root = $doc->documentElement;
+    if (!$root instanceof DOMElement) {
+        $root = $doc->appendChild($doc->createElement('pfsense'));
+    }
+    return $root->appendChild($doc->createElement('filter'));
+}
+
+function remove_existing_rules(DOMXPath $xpath, DOMElement $filterNode): int
+{
+    $count = 0;
+    $nodes = $xpath->query('/pfsense/filter/rule[contains(descr, "[CTX-MGMT]")]');
+    foreach ($nodes as $node) {
+        if ($node instanceof DOMNode) {
+            $filterNode->removeChild($node);
+            $count++;
+        }
+    }
+    return $count;
+}
+
+function get_interface_label(DOMXPath $xpath, string $iface): string
+{
+    $node = $xpath->query('//interfaces/' . $iface . '/descr')->item(0);
+    if ($node instanceof DOMNode) {
+        $label = trim($node->nodeValue ?? '');
+        if ($label !== '') {
+            return $label;
+        }
+    }
+    return strtoupper($iface);
+}
+
+function append_rule(DOMDocument $doc, DOMElement $filterNode, array $data): void
+{
+    $rule = $filterNode->appendChild($doc->createElement('rule'));
+    $rule->appendChild($doc->createElement('type', $data['type'] ?? 'pass'));
+    $rule->appendChild($doc->createElement('interface', $data['interface'] ?? 'lan'));
+    $rule->appendChild($doc->createElement('ipprotocol', $data['ipprotocol'] ?? 'inet'));
+
+    if (!empty($data['direction'])) {
+        $rule->appendChild($doc->createElement('direction', $data['direction']));
+    }
+
+    if (!empty($data['protocol'])) {
+        $rule->appendChild($doc->createElement('protocol', $data['protocol']));
+    }
+
+    if (!empty($data['statetype'])) {
+        $rule->appendChild($doc->createElement('statetype', $data['statetype']));
+    }
+
+    $tracker = $doc->createElement('tracker', generate_tracker());
+    $rule->appendChild($tracker);
+
+    $descrText = $data['descr'] ?? '';
+    if ($descrText !== '') {
+        $descrNode = $doc->createElement('descr');
+        $descrNode->appendChild($doc->createCDATASection($descrText));
+        $rule->appendChild($descrNode);
+    }
+
+    $timestamp = $data['timestamp'] ?? time();
+    $rule->appendChild(build_timestamp_node($doc, 'created', $timestamp));
+    $rule->appendChild(build_timestamp_node($doc, 'updated', $timestamp));
+
+    $sourceNode = $rule->appendChild($doc->createElement('source'));
+    append_address($doc, $sourceNode, $data['source'] ?? 'any');
+
+    $destNode = $rule->appendChild($doc->createElement('destination'));
+    append_address($doc, $destNode, $data['destination'] ?? 'any');
+
+    if (!empty($data['destination_port'])) {
+        $destNode->appendChild($doc->createElement('port', $data['destination_port']));
+    }
+}
+
+function append_address(DOMDocument $doc, DOMElement $parent, string $value): void
+{
+    $value = trim($value);
+    if ($value === '' || strtolower($value) === 'any') {
+        $parent->appendChild($doc->createElement('any'));
+        return;
+    }
+
+    if (preg_match('/^[A-Za-z0-9_]+$/', $value) && !preg_match('/\./', $value) && !preg_match('/:/', $value)) {
+        $parent->appendChild($doc->createElement('network', $value));
+        return;
+    }
+
+    $parent->appendChild($doc->createElement('address', $value));
+}
+
+function build_timestamp_node(DOMDocument $doc, string $name, int $timestamp): DOMElement
+{
+    $node = $doc->createElement($name);
+    $node->appendChild($doc->createElement('time', (string)$timestamp));
+    $node->appendChild($doc->createElement('username', 'context'));
+    return $node;
+}
+
+function generate_tracker(): string
+{
+    static $offset = 0;
+    $offset++;
+    $base = (int)round(microtime(true) * 1000000);
+    return (string)($base + $offset);
+}


### PR DESCRIPTION
## Summary
- support the `mgmt` interface role when configuring NICs from context
- generate management firewall rules from context variables and apply them immediately
- document the new management parameters available in `context.sh`

## Testing
- php -l pfSense/etc/context.d/modules/firewall_mgmt.php
- sh -n pfSense/etc/context.d/modules/firewall.sh
- sh -n pfSense/etc/context.d/modules/interfaces.sh
- sh -n pfSense/etc/context.d/ContextOnly

------
https://chatgpt.com/codex/tasks/task_e_68f64ab78644832886eedaf6b6270e8a